### PR TITLE
[TD-1133] Add default linter configs to standards documentation

### DIFF
--- a/coding-styles/ruby/.rubocop.yml
+++ b/coding-styles/ruby/.rubocop.yml
@@ -1,0 +1,33 @@
+#require: rubocop-rspec
+
+AllCops:
+  Include:
+    - '**/Rakefile'
+    - '**/config.ru'
+  Exclude:
+    - 'bin/**/*'
+    - 'config/**/*'
+    - 'db/**/*'
+    - 'script/**/*'
+    - !ruby/regexp /old_and_unused\.rb$/
+    - 'spec/spec_helper.rb'
+    - 'spec/rails_helper.rb'
+    - 'node_modules/**/*'
+
+Metrics/LineLength:
+  Max: 150
+
+Metrics/MethodLength:
+  Max: 30
+
+Documentation:
+  Enabled: false
+
+Style/FirstParameterIndentation:
+  Enabled: false
+
+Style/IndentArray:
+  EnforcedStyle: consistent
+
+Rails:
+  Enabled: true

--- a/coding-styles/ruby/README.md
+++ b/coding-styles/ruby/README.md
@@ -4,6 +4,7 @@ Inspired by [Bozhidar Batsov Guide](https://github.com/bbatsov/ruby-style-guide)
 
 ## Table of Contents
 
+  1. [Code Linting](#code-linting)
   1. [Whitespace](#whitespace)
   1. [Line Length](#line-length)
   1. [Encoding](#encoding)
@@ -17,6 +18,15 @@ Inspired by [Bozhidar Batsov Guide](https://github.com/bbatsov/ruby-style-guide)
   1. [Collections](#collections)
   1. [Strings](#strings)
   1. [Misc](#misc)
+
+## Code Linting
+
+Where possible use [RuboCop](https://github.com/bbatsov/rubocop) to lint your Ruby source code automatically.
+
+* Enable linting in Sublime Text by installing [SublimeLinter](http://www.sublimelinter.com/en/latest/installation.html)
+* Enable [RuboCop SublimeLinter-Rubocop plugin](http://www.sublimelinter.com/en/latest/installation.html)
+* Ensure `rubocop` is added to your project `Gemfile` and run `bundle install`
+* Copy the [.rubocop.yml](rubocop.yml) file from this repo into your source root folder
 
 ## Whitespace
 

--- a/coding-styles/ruby/README.md
+++ b/coding-styles/ruby/README.md
@@ -24,9 +24,24 @@ Inspired by [Bozhidar Batsov Guide](https://github.com/bbatsov/ruby-style-guide)
 Where possible use [RuboCop](https://github.com/bbatsov/rubocop) to lint your Ruby source code automatically.
 
 * Enable linting in Sublime Text by installing [SublimeLinter](http://www.sublimelinter.com/en/latest/installation.html)
-* Enable [RuboCop SublimeLinter-Rubocop plugin](http://www.sublimelinter.com/en/latest/installation.html)
+* Install the [SublimeLinter-Ruby plugin]
+* Install the [RuboCop SublimeLinter-Rubocop plugin](http://www.sublimelinter.com/en/latest/installation.html)
 * Ensure `rubocop` is added to your project `Gemfile` and run `bundle install`
-* Copy the [.rubocop.yml](.rubocop.yml) file from this repo into your source root folder
+* Choose Tools > SublimeLinter > Lint Mode > Load/Save
+* Choose Tools > SublimeLinter > Choose Gutter Theme > Default
+* Choose Tools > SublimeLinter > Debug Mode
+* Open Sublime Text > Preferences > SublimeLinter > Settings - User and set the `rubocop` section as below:
+
+```json
+"rubocop": {
+    "@disable": false,
+    "args": ["--config", "/path/to/source/standards/coding-styles/ruby/.rubocop.yml"],
+    "excludes": []
+},
+```
+
+* Check it is all working by opening and saving a new `.rb` file. 
+  Make a linting error such as comment without space and it should be displayed in Yellow
 
 ## Whitespace
 

--- a/coding-styles/ruby/README.md
+++ b/coding-styles/ruby/README.md
@@ -26,7 +26,7 @@ Where possible use [RuboCop](https://github.com/bbatsov/rubocop) to lint your Ru
 * Enable linting in Sublime Text by installing [SublimeLinter](http://www.sublimelinter.com/en/latest/installation.html)
 * Enable [RuboCop SublimeLinter-Rubocop plugin](http://www.sublimelinter.com/en/latest/installation.html)
 * Ensure `rubocop` is added to your project `Gemfile` and run `bundle install`
-* Copy the [.rubocop.yml](rubocop.yml) file from this repo into your source root folder
+* Copy the [.rubocop.yml](.rubocop.yml) file from this repo into your source root folder
 
 ## Whitespace
 

--- a/coding-styles/ruby/README.md
+++ b/coding-styles/ruby/README.md
@@ -41,7 +41,7 @@ Where possible use [RuboCop](https://github.com/bbatsov/rubocop) to lint your Ru
 ```
 
 * Check it is all working by opening and saving a new `.rb` file. 
-  Make a linting error such as comment without space and it should be displayed in Yellow
+  Make a linting error such as comment without space and it should be displayed in yellow.
 
 ## Whitespace
 


### PR DESCRIPTION
**Jira Ticket**
https://factorymedia.atlassian.net/browse/TD-1133

**Summary**
Use automated linting tools where available to ensure less code which is not up to standard gets committed

**QA / Testing**
Follow steps in `./coding-styles/ruby/README.me#code-linting` and make sure it works 
- [ ] Documentation is accurate
- [ ] Ruby Linting works as expected
- [ ] Modifying the `.rubocop.yml` has desired effect

> NOTE: I have not tried yet to force Rubocop to adhere to all coding standards in this document
