### PR TITLE
Remove Rails from default .rubocop.yml linter

### DIFF
--- a/coding-styles/ruby/.rubocop.yml
+++ b/coding-styles/ruby/.rubocop.yml
@@ -29,5 +29,9 @@ Style/FirstParameterIndentation:
 Style/IndentArray:
   EnforcedStyle: consistent
 
-Rails:
-  Enabled: true
+Style/FrozenStringLiteralComment:
+  Enabled: false
+  
+# Include this in your local .rubocop.yml file if you are using Rails
+# Rails:
+#   Enabled: true


### PR DESCRIPTION
Remove Rails from the .rubocop.yml defaults
